### PR TITLE
Update themeunittestdata.wordpress.xml

### DIFF
--- a/themeunittestdata.wordpress.xml
+++ b/themeunittestdata.wordpress.xml
@@ -8048,7 +8048,7 @@ There are a few ways to list them.
     <wp:comment_author><![CDATA[Ping 4 &laquo; What&#8217;s a tellyworth?]]></wp:comment_author>
     <wp:comment_author_email/>
     <wp:comment_author_url>http://tellyworth.wordpress.com/2007/11/21/ping-4/</wp:comment_author_url>
-    <wp:comment_author_IP>2</wp:comment_author_IP>
+    <wp:comment_author_IP></wp:comment_author_IP>
     <wp:comment_date>2007-11-21 11:39:25</wp:comment_date>
     <wp:comment_date_gmt>2007-11-21 01:39:25</wp:comment_date_gmt>
     <wp:comment_content><![CDATA[[...] Another short one. [...]]]></wp:comment_content>


### PR DESCRIPTION
Removes a left over number from one of the comment author IP's.