### PR TITLE
Removes extra > from data-link attribute from 2 images

### DIFF
--- a/themeunittestdata.wordpress.xml
+++ b/themeunittestdata.wordpress.xml
@@ -10004,7 +10004,7 @@ Francisco</figcaption></figure></li><li class="blocks-gallery-item"><figure><img
 <!-- /wp:gallery -->
 
 <!-- wp:gallery {"columns":2,"align":"left"} -->
-<ul class="wp-block-gallery alignleft columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://wpthemetestdata.files.wordpress.com/2014/01/spectacles.gif" alt="" data-id="1692" data-link=">https://wpthemetestdata.wordpress.com/about/clearing-floats/spectacles-2/" class="wp-image-1692"/></figure></li><li class="blocks-gallery-item">
+<ul class="wp-block-gallery alignleft columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://wpthemetestdata.files.wordpress.com/2014/01/spectacles.gif" alt="" data-id="1692" data-link="https://wpthemetestdata.wordpress.com/about/clearing-floats/spectacles-2/" class="wp-image-1692"/></figure></li><li class="blocks-gallery-item">
 <figure><img src="https://wpthemetestdata.files.wordpress.com/2012/12/unicorn-wallpaper.jpg" alt="Unicorn Wallpaper" data-id="1045" data-link="https://wpthemetestdata.wordpress.com/2010/08/08/post-format-image/unicorn-wallpaper/" class="wp-image-1045"/></figure></li><li class="blocks-gallery-item"><figure>
 <img src="https://wpthemetestdata.files.wordpress.com/2010/08/manhattansummer.jpg" alt="" data-id="827" data-link="https://wpthemetestdata.wordpress.com/about/clearing-floats/olympus-digital-camera/" class="wp-image-827"/></figure></li><li class="blocks-gallery-item"><figure>
 <img src="https://wpthemetestdata.files.wordpress.com/2012/06/dsc20040724_152504_532.jpg" alt="" data-id="807" data-link="https://wpthemetestdata.wordpress.com/2010/09/10/post-format-gallery/dsc20040724_152504_532-2/" class="wp-image-807"/></figure></li><li class="blocks-gallery-item">
@@ -10114,7 +10114,7 @@ Raindrop ripples on a pond</figcaption></figure></li><li class="blocks-gallery-i
 
 <!-- wp:gallery {"columns":7} -->
 <ul class="wp-block-gallery columns-7 is-cropped"><li class="blocks-gallery-item"><figure>
-<img src="https://wpthemetestdata.files.wordpress.com/2014/01/spectacles.gif" alt="" data-id="1692" data-link=">https://wpthemetestdata.wordpress.com/about/clearing-floats/spectacles-2/" class="wp-image-1692"/></figure></li>
+<img src="https://wpthemetestdata.files.wordpress.com/2014/01/spectacles.gif" alt="" data-id="1692" data-link="https://wpthemetestdata.wordpress.com/about/clearing-floats/spectacles-2/" class="wp-image-1692"/></figure></li>
 <li class="blocks-gallery-item"><figure><img src="https://wpthemetestdata.files.wordpress.com/2014/01/dsc20050315_145007_132.jpg" alt="" data-id="1691" 
 data-link="https://wpthemetestdata.wordpress.com/2010/09/10/post-format-gallery/dsc20050315_145007_132-2/" class="wp-image-1691"/></figure></li><li class="blocks-gallery-item">
 <figure><img src="https://wpthemetestdata.files.wordpress.com/2008/06/dsc20050604_133440_34211.jpg" alt="" data-id="1687" data-link="https://wpthemetestdata.wordpress.com/2010/09/10/post-format-gallery/dsc20050604_133440_3421/" class="wp-image-1687"/></figure></li><li class="blocks-gallery-item">


### PR DESCRIPTION
Fixes #36 by removing extra `>` from `data-link` attribute in 2 images on the Gallery post